### PR TITLE
Creates syntactically valid old-style ASCII property lists

### DIFF
--- a/Commands/Convert to Pretty ASCII.tmCommand
+++ b/Commands/Convert to Pretty ASCII.tmCommand
@@ -6,10 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/sh
-if ! /usr/bin/plutil -convert xml1 -o - -- - | /usr/bin/pl; then
-	. "$TM_SUPPORT_PATH/lib/bash_init.sh"
-	exit_show_tool_tip
-fi
+exec "${TM_BUNDLE_SUPPORT}/bin/pretty_plist"
 </string>
 	<key>input</key>
 	<string>document</string>
@@ -18,7 +15,7 @@ fi
 	<key>keyEquivalent</key>
 	<string>^H</string>
 	<key>name</key>
-	<string>Convert to Old-Style ASCII</string>
+	<string>Convert to Pretty ASCII</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>
@@ -26,9 +23,9 @@ fi
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.plist, text.xml.plist</string>
+	<string>text.xml.plist, source.plist.binary</string>
 	<key>uuid</key>
-	<string>827E8A23-2C7A-4BDD-987F-A3B67B51F239</string>
+	<string>7BB2E008-C144-4898-AD7D-3C27ACFBA10A</string>
 	<key>version</key>
 	<integer>2</integer>
 </dict>

--- a/info.plist
+++ b/info.plist
@@ -54,6 +54,7 @@
 					<string>9EE98508-0697-4220-8D0F-A7E393703FE5</string>
 					<string>596D33EB-DACF-4B92-97E7-501AF5A3BAED</string>
 					<string>1CE7E2B3-0A9B-4BA4-A5ED-91E62775C93E</string>
+					<string>7BB2E008-C144-4898-AD7D-3C27ACFBA10A</string>
 				</array>
 				<key>name</key>
 				<string>Convert</string>


### PR DESCRIPTION
This uses a combination of `plutil` and `pl` to create the ASCII format property list representation. First, `plutil` converts the property list to XML format for consumption by `pl`. Then `pl` converts the XML into old-style ASCII format. The output from `pl` is formatted identically to that of `defaults`.

This also adds a 'Convert to Pretty ASCII' command in order to preserve the existing functionality that uses `pretty_plist`.